### PR TITLE
Disable solute-solute interactions across PBC

### DIFF
--- a/absolv/tests/conftest.py
+++ b/absolv/tests/conftest.py
@@ -181,9 +181,12 @@ def aq_nacl_topology() -> Topology:
 @pytest.fixture(scope="module")
 def aq_meoh_topology() -> Topology:
 
-    return Topology.from_molecules(
+    topology = Topology.from_molecules(
         [Molecule.from_smiles("CO")] + [Molecule.from_smiles("O")] * 2
     )
+    topology.box_vectors = (numpy.eye(3) * 5.0) * unit.nanometers
+
+    return topology
 
 
 @pytest.fixture(scope="module")

--- a/absolv/tests/test_simulations.py
+++ b/absolv/tests/test_simulations.py
@@ -44,6 +44,7 @@ def _build_alchemical_lj_system(
     force = openmm.NonbondedForce()
     force.setNonbondedMethod(openmm.NonbondedForce.CutoffPeriodic)
     force.setCutoffDistance(6.0 * unit.angstrom)
+    force.setUseDispersionCorrection(False)
 
     system.addForce(force)
 


### PR DESCRIPTION
## Description

This PR takes the [GROMACS approach](https://manual.gromacs.org/documentation/current/user-guide/mdp-options.html#mdp-couple-intramol) of converting 1-n (where n > 4) intramolecular vdW interactions into explicit pair interactions that do not apply PBC corrections. 

This should ensure that when the solute-solvent interactions are disabled the solute exists in a state as identical as possible to the solute in vacuum.

## Status
- [X] Ready to go