### PR TITLE
Allow custom soft-core potential

### DIFF
--- a/absolv/factories/alchemical.py
+++ b/absolv/factories/alchemical.py
@@ -476,11 +476,12 @@ class OpenMMAlchemicalFactory:
          transformed from a base chemical system.
 
         Notes:
-            * By default the a soft-core version of the LJ potential with a-b-c of 1-1-6
+            * By default a soft-core version of the LJ potential with a-b-c of 1-1-6
               and alpha=0.5 that can be scaled by a global `lambda_sterics` parameter
-              will be used for vdW interactions embedded in an OpenMM ``NonbondedForce``
-              while the energy expression set on a ``CustomNonbondedForce`` will be be
-              modified to have the form ``"lambda_sterics*({original_expression})"``.
+              will be used for alchemical-chemical vdW interactions embedded in an
+              OpenMM ``NonbondedForce`` while the energy expression set on a
+              ``CustomNonbondedForce`` will be be modified to have the form
+              ``"lambda_sterics*({original_expression})"``.
 
         Args:
             system: The chemical system to generate the alchemical system from

--- a/absolv/runners/_runners.py
+++ b/absolv/runners/_runners.py
@@ -58,6 +58,7 @@ class BaseRunner:
         force_field: Union[ForceField, SystemGenerator],
         n_solute_molecules: int,
         n_solvent_molecules: int,
+        custom_alchemical_potential: Optional[str] = None,
     ):
         """Creates the input files for a particular solvent phase.
 
@@ -80,6 +81,11 @@ class BaseRunner:
                 ``"solvent-b"``.
             n_solute_molecules: The number of solute molecule.
             n_solvent_molecules: The number of solvent molecule.
+            custom_alchemical_potential: A custom expression to use for the potential
+                energy function that describes the chemical-alchemical intermolecular
+                interactions.
+
+                See the ``OpenMMAlchemicalFactory.generate`` function for more details.
         """
 
         is_vacuum = n_solvent_molecules == 0
@@ -98,7 +104,10 @@ class BaseRunner:
             original_system: openmm.System = force_field(topology, solvent_index)
 
         alchemical_system = OpenMMAlchemicalFactory.generate(
-            original_system, alchemical_indices, persistent_indices
+            original_system,
+            alchemical_indices,
+            persistent_indices,
+            custom_alchemical_potential,
         )
 
         topology.to_file("coords-initial.pdb", coordinates)
@@ -119,6 +128,7 @@ class BaseRunner:
         schema: TransferFreeEnergySchema,
         force_field: Union[ForceField, SystemGenerator],
         directory: str = "absolv-experiment",
+        custom_alchemical_potential: Optional[str] = None,
     ):
         """Prepare the input files needed to compute the free energy and store them
         in the specified directory.
@@ -131,6 +141,11 @@ class BaseRunner:
             force_field: The force field (or system generator) to use to generate
                 the chemical system object.
             directory: The directory to create the input files in.
+            custom_alchemical_potential: A custom expression to use for the potential
+                energy function that describes the chemical-alchemical intermolecular
+                interactions.
+
+                See the ``OpenMMAlchemicalFactory.generate`` function for more details.
         """
 
         n_solute_molecules = schema.system.n_solute_molecules
@@ -152,6 +167,7 @@ class BaseRunner:
                     force_field,
                     n_solute_molecules,
                     n_solvent_molecules,
+                    custom_alchemical_potential,
                 )
 
         with open(os.path.join(directory, "schema.json"), "w") as file:


### PR DESCRIPTION
## Description

This PR aims to add initial support for using a custom soft-core potential in the alchemical system factory. This allows users to, for example, use custom LJ mixing rules while still applying a soft-core potential, e.g.

```
from absolv.factories.alchemical import soft_core_lj_potential

custom_alchemical_potential = (
    soft_core_lj_potential()
    + "sigma = sqrt(sigma1*sigma2); epsilon = sqrt(epsilon1*epsilon2);"
)

EquilibriumRunner.setup(
    schema, myff, custom_alchemical_potential=custom_alchemical_potential
)
```

## Status
- [X] Ready to go