### PR TITLE
Improve support for OpenMM force fields with v-sites

### DIFF
--- a/absolv/factories/alchemical.py
+++ b/absolv/factories/alchemical.py
@@ -59,6 +59,16 @@ class OpenMMAlchemicalFactory:
             for atom_index in indices
         }
 
+        particle_to_atom_index = {}
+        atom_index = 0
+
+        for particle_index in range(system.getNumParticles()):
+            if system.isVirtualSite(particle_index):
+                continue
+
+            particle_to_atom_index[particle_index] = atom_index
+            atom_index += 1
+
         atom_index = 0
 
         remapped_atom_indices: List[Set[int]] = [
@@ -75,7 +85,7 @@ class OpenMMAlchemicalFactory:
             else:
 
                 v_site = system.getVirtualSite(particle_index)
-                parent_atom_index = v_site.getParticle(0)
+                parent_atom_index = particle_to_atom_index[v_site.getParticle(0)]
 
                 molecule_index = atom_to_molecule_index[parent_atom_index]
 

--- a/absolv/runners/_runners.py
+++ b/absolv/runners/_runners.py
@@ -73,12 +73,12 @@ class BaseRunner:
                 and the remaining ``n_solvent_molecules`` entries correspond to molecules
                 that will not.
             force_field: The force field, or a callable that transforms an OpenFF
-                topology into an OpenMM system **without** any alchemical modifications,
+                topology into an OpenMM system, **without** any alchemical modifications
                 to run the calculations using.
 
                 If a callable is specified, it should take arguments of an OpenFF
-                topology and a string literal with a value of either ``"solvent-a"`` or
-                ``"solvent-b"``.
+                topology, a unit wrapped numpy array of atom coordinates, and a string
+                literal with a value of either ``"solvent-a"`` or ``"solvent-b"``.
             n_solute_molecules: The number of solute molecule.
             n_solvent_molecules: The number of solvent molecule.
             custom_alchemical_potential: A custom expression to use for the potential
@@ -101,7 +101,9 @@ class BaseRunner:
         if isinstance(force_field, ForceField):
             original_system = force_field.create_openmm_system(topology)
         else:
-            original_system: openmm.System = force_field(topology, solvent_index)
+            original_system: openmm.System = force_field(
+                topology, coordinates, solvent_index
+            )
 
         alchemical_system = OpenMMAlchemicalFactory.generate(
             original_system,
@@ -136,10 +138,12 @@ class BaseRunner:
         Args:
             schema: The schema defining the calculation to perform.
             force_field: The force field, or a callable that transforms an OpenFF
-                topology and a set of coordinates into an OpenMM system **without**
-                any alchemical modifications, to run the calculations using.
-            force_field: The force field (or system generator) to use to generate
-                the chemical system object.
+                topology into an OpenMM system, **without** any alchemical modifications
+                to run the calculations using.
+
+                If a callable is specified, it should take arguments of an OpenFF
+                topology, a unit wrapped numpy array of atom coordinates, and a string
+                literal with a value of either ``"solvent-a"`` or ``"solvent-b"``.
             directory: The directory to create the input files in.
             custom_alchemical_potential: A custom expression to use for the potential
                 energy function that describes the chemical-alchemical intermolecular

--- a/absolv/tests/factories/test_alchemical.py
+++ b/absolv/tests/factories/test_alchemical.py
@@ -15,17 +15,25 @@ from absolv.tests import is_close
 
 
 class TestOpenMMAlchemicalFactory:
-    def test_find_v_sites(self, aq_nacl_lj_system):
+    def test_find_v_sites(self):
         """Ensure that v-sites are correctly detected from an OMM system and assigned
         to the right parent molecule."""
 
-        atom_indices = [{0}, {1}, {2, 3, 4}, {5, 6, 7}]
+        # Construct a mock system of V A A A V A A where (0, 5, 6), (3,), (4, 1, 2)
+        # are the core molecules.
+        system = openmm.System()
 
-        particle_indices = OpenMMAlchemicalFactory._find_v_sites(
-            aq_nacl_lj_system, atom_indices
-        )
+        for i in range(7):
+            system.addParticle(1.0)
 
-        assert particle_indices == [{0}, {1}, {2, 3, 4, 8}, {5, 6, 7, 9}]
+        system.setVirtualSite(0, openmm.TwoParticleAverageSite(5, 6, 0.5, 0.5))
+        system.setVirtualSite(4, openmm.TwoParticleAverageSite(1, 2, 0.5, 0.5))
+
+        atom_indices = [{0, 1}, {2}, {3, 4}]
+
+        particle_indices = OpenMMAlchemicalFactory._find_v_sites(system, atom_indices)
+
+        assert particle_indices == [{1, 2, 4}, {3}, {0, 5, 6}]
 
     def test_find_nonbonded_forces_lj_only(self, aq_nacl_lj_system):
 

--- a/absolv/tests/factories/test_alchemical.py
+++ b/absolv/tests/factories/test_alchemical.py
@@ -19,11 +19,13 @@ class TestOpenMMAlchemicalFactory:
         """Ensure that v-sites are correctly detected from an OMM system and assigned
         to the right parent molecule."""
 
-        initial_atom_indices = [{0}, {1}, {2, 3, 4}, {5, 6, 7}]
+        atom_indices = [{0}, {1}, {2, 3, 4}, {5, 6, 7}]
 
-        OpenMMAlchemicalFactory._find_v_sites(aq_nacl_lj_system, initial_atom_indices)
+        particle_indices = OpenMMAlchemicalFactory._find_v_sites(
+            aq_nacl_lj_system, atom_indices
+        )
 
-        assert initial_atom_indices == [{0}, {1}, {2, 3, 4, 8}, {5, 6, 7, 9}]
+        assert particle_indices == [{0}, {1}, {2, 3, 4, 8}, {5, 6, 7, 9}]
 
     def test_find_nonbonded_forces_lj_only(self, aq_nacl_lj_system):
 

--- a/absolv/tests/runners/test_runners.py
+++ b/absolv/tests/runners/test_runners.py
@@ -48,7 +48,7 @@ class TestBaseRunner(BaseTemporaryDirTest):
         "force_field",
         [
             ForceField("openff-2.0.0.offxml"),
-            lambda topology, _: ForceField("openff-2.0.0.offxml").create_openmm_system(
+            lambda topology, *_: ForceField("openff-2.0.0.offxml").create_openmm_system(
                 topology
             ),
         ],

--- a/absolv/tests/utilities/test_openmm.py
+++ b/absolv/tests/utilities/test_openmm.py
@@ -208,7 +208,9 @@ def test_create_system():
     )
     topology.box_vectors = numpy.eye(3) * 30.21 * unit.angstrom
 
-    system_a = system_generator(topology, "solvent-a")
+    coordinates = numpy.zeros((topology.n_topology_atoms, 3)) * unit.angstrom
+
+    system_a = system_generator(topology, coordinates, "solvent-a")
     assert isinstance(system_a, openmm.System)
     assert is_close(
         system_a.getDefaultPeriodicBoxVectors()[0][0], 30.21 * unit.angstrom
@@ -225,7 +227,7 @@ def test_create_system():
 
     topology.box_vectors = None
 
-    system_b = system_generator(topology, "solvent-b")
+    system_b = system_generator(topology, coordinates, "solvent-b")
     assert isinstance(system_b, openmm.System)
     assert is_close(system_b.getDefaultPeriodicBoxVectors()[0][0], 20.0 * unit.angstrom)
     assert system_b.getNumConstraints() == 3


### PR DESCRIPTION
## Description

This PR improves support when using OpenMM force fields that add v-sites by:

* fixing `_find_v_sites` to not always expect v-sites to be added to the end of the topology
* making sure v-sites are added to the topology prior to creating the system in the default system generator

## Status
- [X] Ready to go