### PR TITLE
Disable repex error target

### DIFF
--- a/absolv/simulations.py
+++ b/absolv/simulations.py
@@ -448,7 +448,7 @@ class RepexAlchemicalOpenMMSimulation:
             ),
             online_analysis_interval=None,
             online_analysis_target_error=None,
-            online_analysis_minimum_iterations=None
+            online_analysis_minimum_iterations=None,
         )
         simulation.create(
             thermodynamic_states=compound_states,

--- a/absolv/simulations.py
+++ b/absolv/simulations.py
@@ -446,6 +446,9 @@ class RepexAlchemicalOpenMMSimulation:
                 reassign_velocities=True,
                 n_restart_attempts=6,
             ),
+            online_analysis_interval=None,
+            online_analysis_target_error=None,
+            online_analysis_minimum_iterations=None
         )
         simulation.create(
             thermodynamic_states=compound_states,


### PR DESCRIPTION
## Description

This PR stops the replica exchange sampler from ending the simulation when it reaches the default 'error target'. It instead now correctly runs for the requested length of time.

## Status
- [X] Ready to go